### PR TITLE
update setup.py url and classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     long_description=readme + '\n\n' + doclink + '\n\n' + history,
     author='Benjamin Bach',
     author_email='benjamin@overtag.dk',
-    url='https://github.com/benjaoming/modeltranslation_wagtail',
+    url='https://github.com/benjaoming/django-modeltranslation-wagtail',
     packages=[
         'modeltranslation_wagtail',
     ],
@@ -52,5 +52,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: Implementation :: PyPy',
+        'Framework :: Django',
+        'Topic :: Software Development :: Internationalization',
     ],
 )


### PR DESCRIPTION
/^ *url=/s/modeltranslation_wagtail/django-modeltranslation-wagtail/
Also, add django and i18n to PyPI classifiers.

Fixes the link from PyPI to the repository, and, to make up for being such a trivial commit, adds the two most relevant classifiers as well.

Thanks for sharing your code! :smile: 